### PR TITLE
Remove dependency on `unstable-list-lib`

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -7,5 +7,4 @@
                "rackunit-lib"
                "sandbox-lib"
                "syntax-color-lib"
-               "unstable-list-lib"
                "wxme-lib"))

--- a/racketeer/private/testing-mixin.rkt
+++ b/racketeer/private/testing-mixin.rkt
@@ -5,6 +5,7 @@
          framework
          mrlib/switchable-button
          racket/class
+         racket/function
          racket/gui/base
          racket/gui
          racket/unit
@@ -13,7 +14,6 @@
          test-engine/racket-tests
          rackunit
          syntax-color/module-lexer
-         unstable/function
          wxme)
 
 ;; CONSTANTS

--- a/racketeer/tool.rkt
+++ b/racketeer/tool.rkt
@@ -5,8 +5,8 @@
 (require drracket/tool
          framework
          racket/class
+         racket/function
          racket/gui
-         unstable/function
          "private/testing-mixin.rkt")
 
 (import drracket:tool^)


### PR DESCRIPTION
Most of the functionality of that package will be moved into the core libraries by Racket PR #972, and `unstable-list-lib` will be removed from the main distribution.

This PR makes this package incompatible with Racket 6.2. To preserve compatibility, you can create a Racket 6.2-compatible branch in this repository and set up a version exception at pkgs.racket-lang.org

Even without the changes from this PR, this package will continue to work with future versions of Racket. It will, however, require installation of the `unstable-list-lib` package, as it will not be part of the main distribution in future versions.
